### PR TITLE
Add OpenAPI extensions for API auto-routing

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,26 +1,26 @@
 name: Run prettier to check style on pull requests
 
 on:
-  pull_request:
-    branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  prettier:
-    runs-on: ubuntu-latest
+    prettier:
+        runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        # Make sure the actual branch is checked out when running on pull requests
-        ref: ${{ github.head_ref }}
-        # This is important to fetch the changes to the previous commit
-        fetch-depth: 0
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  # Make sure the actual branch is checked out when running on pull requests
+                  ref: ${{ github.head_ref }}
+                  # This is important to fetch the changes to the previous commit
+                  fetch-depth: 0
 
-    - name: Check code style
-      uses: creyD/prettier_action@v3.1
-      with:
-        dry: true
-        prettier_options: --write *
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Check code style
+              uses: creyD/prettier_action@v3.1
+              with:
+                  dry: true
+                  prettier_options: --write *
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 dist
 node_modules
 .vscode
+package-lock.json
+docs/*.html

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 default:
 	echo "Build not implemented yet"
 
+pretty:
+	prettier -w .
+
 gen-api:
 	openapi-generator-cli generate -i api/openapi.yaml -g nodejs-express-server -o .
 
@@ -14,4 +17,4 @@ render-docs:
 lint-docs:
 	openapi lint api/openapi.yaml
 
-.PHONY: gen-api serve-docs render-docs lint-docs
+.PHONY: pretty gen-api serve-docs render-docs lint-docs

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -58,6 +58,8 @@ paths:
             tags:
                 - blog
             summary: Get a list of blogs
+            x-eov-operation-id: apiBlogsGET
+            x-eov-operation-handler: controllers/BlogController
             parameters:
                 - name: author
                   in: query
@@ -94,6 +96,8 @@ paths:
                 - blog
             summary: Create a new blog
             description: This can only be done by users who have logged in.
+            x-eov-operation-id: apiBlogsPOST
+            x-eov-operation-handler: controllers/BlogController
             responses:
                 '201':
                     description:
@@ -110,6 +114,8 @@ paths:
             tags:
                 - blog
             summary: Get blog details
+            x-eov-operation-id: apiBlogsUuidGET
+            x-eov-operation-handler: controllers/BlogController
             parameters:
                 - name: uuid
                   in: path
@@ -131,6 +137,8 @@ paths:
             description:
                 This can only be done by users who have logged in and on blogs
                 that the user has authored.
+            x-eov-operation-id: apiBlogsUuidPUT
+            x-eov-operation-handler: controllers/BlogController
             parameters:
                 - name: uuid
                   in: path
@@ -158,6 +166,8 @@ paths:
             description:
                 This can only be done by users who have logged in and on blogs
                 that the user has authored.
+            x-eov-operation-id: apiBlogsUuidDELETE
+            x-eov-operation-handler: controllers/BlogController
             parameters:
                 - name: uuid
                   in: path
@@ -181,6 +191,8 @@ paths:
             tags:
                 - user
             summary: Get user information
+            x-eov-operation-id: apiUserGET
+            x-eov-operation-handler: controllers/UserController
             parameters:
                 - name: user
                   in: query
@@ -200,6 +212,8 @@ paths:
                 - user
             summary: Update user information
             description: This can only be done by users who have logged in.
+            x-eov-operation-id: apiUserPUT
+            x-eov-operation-handler: controllers/UserController
             responses:
                 '200':
                     description: Success.
@@ -213,6 +227,8 @@ paths:
                 - follow
             summary: Add a follow entry
             description: This can only be done by users who have logged in.
+            x-eov-operation-id: apiFollowPOST
+            x-eov-operation-handler: controllers/FollowController
             parameters:
                 - name: user
                   in: query
@@ -230,6 +246,8 @@ paths:
                 - follow
             summary: Delete a follow entry
             description: This can only be done by users who have logged in.
+            x-eov-operation-id: apiFollowDELETE
+            x-eov-operation-handler: controllers/FollowController
             parameters:
                 - name: user
                   in: query
@@ -251,6 +269,8 @@ paths:
             tags:
                 - search
             summary: Search for blogs
+            x-eov-operation-id: apiSearchGET
+            x-eov-operation-handler: controllers/SearchController
             parameters:
                 - name: keyword
                   in: query

--- a/expressServer.js
+++ b/expressServer.js
@@ -58,7 +58,7 @@ class ExpressServer {
                 apiSpec: this.openApiPath,
                 operationHandlers: path.join(__dirname),
                 fileUploader: { dest: config.FILE_UPLOAD_PATH },
-                validateResponse: true,
+                validateResponses: true,
             })
         )
 

--- a/services/BlogService.js
+++ b/services/BlogService.js
@@ -12,13 +12,7 @@ const Service = require('./Service')
 const apiBlogsGET = ({ author, cursor, limit }) =>
     new Promise(async (resolve, reject) => {
         try {
-            resolve(
-                Service.successResponse({
-                    author,
-                    cursor,
-                    limit,
-                })
-            )
+            resolve(Service.successResponse([1, 10, 100]))
         } catch (e) {
             reject(
                 Service.rejectResponse(


### PR DESCRIPTION
Adds extensions to OpenAPI yaml to allow `express-openapi-validator` to create API routes dynamically.

Also includes some code auto-formatting.

:shipit: 